### PR TITLE
fix(monarq): utiliser 'yamaska' comme nom de machine API

### DIFF
--- a/qiskit_calculquebec/backends/monarq_backend.py
+++ b/qiskit_calculquebec/backends/monarq_backend.py
@@ -87,7 +87,7 @@ class MonarQBackend(Backend):
             self._client.machine_name = "yukon"
             self._target = Yukon()
         elif machine_name.lower() == "monarq":
-            self._client.machine_name = "monarq"
+            self._client.machine_name = "yamaska"
             self._target = MonarQ()
 
         self.name = self._target.name

--- a/qiskit_calculquebec/backends/targets/monarq.py
+++ b/qiskit_calculquebec/backends/targets/monarq.py
@@ -131,9 +131,9 @@ class MonarQ(AnyonTarget):
         and benchmark information from the API.
 
         Returns:
-            str: The device name ``"MonarQ"``.
+            str: The device name ``"yamaska"``.
         """
-        return "MonarQ"
+        return "yamaska"
 
     def __init__(self):
         """Initialize the MonarQ target.

--- a/tests/backends/targets/test_monarq.py
+++ b/tests/backends/targets/test_monarq.py
@@ -158,7 +158,7 @@ def test_coupling_map(monarq_target):
 
 
 def test_name(monarq_target):
-    assert monarq_target.name == "MonarQ"
+    assert monarq_target.name == "yamaska"
 
 
 def test_qubit_properties(monarq_target):


### PR DESCRIPTION
## Contexte

L'API AnyonLabs a renommé la machine `monarq` en `yamaska` côté serveur. La requête `?machineName=monarq` retournait une liste vide, causant une `IndexError` au chargement des calibrations.

## Changements

- `targets/monarq.py` — `device_name()` retourne `"yamaska"`
- `monarq_backend.py` — `machine_name` envoyé avec chaque job est `"yamaska"`

## Interface utilisateur

Inchangée : `MonarQBackend("monarq", client)` fonctionne toujours.

## Validation

Testé contre l'API de production :
```
num_qubits = 24
```
Aucune `IndexError`, calibrations chargées correctement.