### PR TITLE
fix: importer QubitProperties depuis qiskit.providers

### DIFF
--- a/qiskit_calculquebec/backends/targets/anyon_target.py
+++ b/qiskit_calculquebec/backends/targets/anyon_target.py
@@ -22,7 +22,7 @@ from qiskit.circuit.library import (
     Measure,
 )
 from qiskit.circuit import Parameter, Delay
-from qiskit.transpiler.target import QubitProperties
+from qiskit.providers import QubitProperties
 from qiskit.transpiler import InstructionProperties
 
 from qiskit_calculquebec.API.adapter import ApiAdapter

--- a/tests/backends/targets/test_monarq.py
+++ b/tests/backends/targets/test_monarq.py
@@ -162,7 +162,7 @@ def test_name(monarq_target):
 
 
 def test_qubit_properties(monarq_target):
-    from qiskit.transpiler.target import QubitProperties
+    from qiskit.providers import QubitProperties
 
     qubit_props, gate_properties = monarq_target.__get_qubit_properties__()
     assert isinstance(qubit_props, list)

--- a/tests/backends/targets/test_yukon.py
+++ b/tests/backends/targets/test_yukon.py
@@ -106,7 +106,7 @@ def test_name(yukon_target):
 
 
 def test_qubit_properties(yukon_target):
-    from qiskit.transpiler.target import QubitProperties
+    from qiskit.providers import QubitProperties
 
     qubit_props, gate_properties = yukon_target.__get_qubit_properties__()
     assert isinstance(qubit_props, list)


### PR DESCRIPTION
## Contexte

Dans Qiskit 2.5, `QubitProperties` a été retiré de `qiskit.transpiler.target`, causant une `ImportError` au chargement du plugin.

## Changement

- `targets/anyon_target.py` — import depuis `qiskit.providers` au lieu de `qiskit.transpiler.target`

## Compatibilité

Compatible avec Qiskit 2.3+. Les tests unitaires passent (48/48).